### PR TITLE
Custom device

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,42 @@ Channel - Function
 4. Stick L X (X Rotation)
 5. Button 1, 2, 3 (Low, Mid, Max)
 6. Z
-7. Button 4, 5, 6
-8. Z rotation
-9. Button 7, 8, 9
-10. Button 10, 11, 12
-11. Button 13, 14, 15
-12. Button 16, 17, 18
-13. Button 19, 20, 21
-14. Button 22, 23, 24
-15. Button 25, 26, 27
-16. Button 28, 29, 30
-17. Button 31 (Digital ch1)
-18. Button 32 (Digital ch2)
+7. Z rotation
+8. Slider
+9. Dial
+10. Button 4, 5, 6
+11. Button 7, 8, 9,
+12. Button 10, 11, 12
+13. Button 13, 14, 15
+14. Button 16, 17, 18
+15. Button 19, 20, 21
+16. Button 22, 23, 24
+17. Button 25
+18. Button 26
+
+## TX Settings
+These are the function settins on my Futaba T16IZ. I ran out of switches for channels 15 and 16.
+
+|Ch.| Function  | Control |
+|---|-----------|---------|
+| 1 | Aileron   | J1      |
+| 2 | Elevator  | J2      |
+| 3 | Throttle  | J3      |
+| 4 | Rudder    | J4      |
+| 5 | Gear      | SE      |
+| 6 | Air Brake | LS      |
+| 7 | Aux 5     | RS      |
+| 8 | Aux 4     | LD      |
+| 9 | Aux 3     | RD      |
+|10 | Aux 2     | SF      |
+|11 | Aux 1     | SH      |
+|12 | Aux 6     | SG      |
+|13 | Aux 7     | SC      |
+|14 | Camber    | SB      |
+|15 | Flap      | N/A     |
+|16 | Motor     | N/A     |
+|DG1| N/A       | SD      |
+|DG2| N/A       | SA      |
 
 # Pinout
 The circuit can be powered by the PICO VBUS and 3V3(out) pins when plugged in USB.

--- a/custom-device/rc-joy-hid.h
+++ b/custom-device/rc-joy-hid.h
@@ -1,0 +1,51 @@
+#ifndef _RC_JOY_HID_H_
+#define _RC_JOY_HID_H_
+
+#include "tusb.h"
+
+#define TUD_HID_REPORT_DESC_RCGAMEPAD(...) \
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
+    /* Report ID if any */\
+    __VA_ARGS__ \
+    /* 12 bit X, Y, Z, Rz, Rx, Ry (min 0, max 2048 ) */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_X                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Y                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RX                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RY                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RZ                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_SLIDER               ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_DIAL                 ) ,\
+    HID_LOGICAL_MIN_N  ( 0, 2                                   ) ,\
+    HID_LOGICAL_MAX_N  ( (int16_t)2048, 2                       ) ,\
+    HID_REPORT_COUNT   ( 8                                      ) ,\
+    HID_REPORT_SIZE    ( 16                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 32 bit Button Map */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_BUTTON                  ) ,\
+    HID_USAGE_MIN      ( 1                                      ) ,\
+    HID_USAGE_MAX      ( 32                                     ) ,\
+    HID_LOGICAL_MIN    ( 0                                      ) ,\
+    HID_LOGICAL_MAX    ( 1                                      ) ,\
+    HID_REPORT_COUNT   ( 32                                     ) ,\
+    HID_REPORT_SIZE    ( 1                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+  HID_COLLECTION_END \
+
+typedef struct TU_ATTR_PACKED
+{
+	uint16_t x;
+	uint16_t y;
+	uint16_t rx;
+	uint16_t ry;
+	uint16_t ls;
+	uint16_t rs;
+	uint16_t ld;
+	uint16_t rd;
+	uint32_t buttons;
+} hid_rcgamepad_report_t;
+
+#endif

--- a/input-mapping.c
+++ b/input-mapping.c
@@ -18,37 +18,31 @@ void get_input_map(input_map_t *map)
     map->rx = INPUT_DEFAULT_XR;
     map->ry = INPUT_DEFAULT_YR;
 
-    map->z = INPUT_DEFAULT_Z;
-    map->rz = INPUT_DEFAULT_ZR;
+    map->ls = INPUT_DEFAULT_LS;
+    map->rs = INPUT_DEFAULT_RS;
+
+    map->ld = INPUT_DEFAULT_LD;
+    map->rd = INPUT_DEFAULT_RD;
 
     int bttn=0;
 
     map->button_map[bttn].channel = 4;
     map->button_map[bttn++].type = BUTTON_3POS_LOW;
 
-    B32(map->button_map[bttn].channel = 4);
-    B32(map->button_map[bttn++].type = BUTTON_3POS_MID);
+    map->button_map[bttn].channel = 4;
+    map->button_map[bttn++].type = BUTTON_3POS_MID;
 
     map->button_map[bttn].channel = 4;
     map->button_map[bttn++].type = BUTTON_3POS_HIGH;
 
-    map->button_map[bttn].channel = 6;
-    map->button_map[bttn++].type = BUTTON_3POS_LOW;
-
-    B32(map->button_map[bttn].channel = 6);
-    B32(map->button_map[bttn++].type = BUTTON_3POS_MID);
-
-    map->button_map[bttn].channel = 6;
-    map->button_map[bttn++].type = BUTTON_3POS_HIGH;
-
     // last 2 channels are the digital channels
-    for (int channel = 8; bttn < (INPUT_MAX_BUTTONS - 2) && channel < (SBUS_CHANNEL_COUNT - 2); channel++)
+    for (int channel = 9; bttn < (INPUT_MAX_BUTTONS - 2) && channel < (SBUS_CHANNEL_COUNT - 2); channel++)
     {
         map->button_map[bttn].channel = channel;
         map->button_map[bttn++].type = BUTTON_3POS_LOW;
 
-        B32(map->button_map[bttn].channel = channel);
-        B32(map->button_map[bttn++].type = BUTTON_3POS_MID);
+        map->button_map[bttn].channel = channel;
+        map->button_map[bttn++].type = BUTTON_3POS_MID;
 
         map->button_map[bttn].channel = channel;
         map->button_map[bttn++].type = BUTTON_3POS_HIGH;
@@ -72,11 +66,12 @@ bool parse_input_map(uint8_t *data, size_t data_size, input_map_t *newMap)
     memcpy(newMap, data, sizeof(input_map_t));
 }
 
-uint8_t getAxisFromSbus(const sbus_state_t *sbus, int channel)
+int16_t getAxisFromSbus(const sbus_state_t *sbus, int channel)
 {
-    int16_t smallerValue = sbus->ch[channel] >> 3;
+    //int16_t smallerValue = sbus->ch[channel] >> 3;
 
-    return smallerValue - 127;
+    //return smallerValue - 127;
+    return sbus->ch[channel];
 }
 
 bool isPressed(const sbus_state_t *sbus, const input_button_mapping_item_t *map)
@@ -102,7 +97,7 @@ bool isPressed(const sbus_state_t *sbus, const input_button_mapping_item_t *map)
     return false;
 }
 
-void sbus2gamepad_report(const input_map_t *map, const sbus_state_t *sbus, hid_gamepad_report_t *hid)
+void sbus2gamepad_report(const input_map_t *map, const sbus_state_t *sbus, hid_rcgamepad_report_t *hid)
 {
 
 }

--- a/input-mapping.h
+++ b/input-mapping.h
@@ -6,6 +6,8 @@
 #include "tusb.h"
 #include "sbus.h"
 
+#include "custom-device/rc-joy-hid.h"
+
 #define INPUT_MAX_BUTTONS 32
 
 typedef enum input_button_type {
@@ -28,8 +30,11 @@ typedef struct {
 #define INPUT_DEFAULT_XR 0
 #define INPUT_DEFAULT_YR 1
 
-#define INPUT_DEFAULT_Z  5
-#define INPUT_DEFAULT_ZR 7
+#define INPUT_DEFAULT_LD 7
+#define INPUT_DEFAULT_RD 8
+
+#define INPUT_DEFAULT_LS 5
+#define INPUT_DEFAULT_RS 6
 
 typedef struct __attribute__((__packed__)) {
     // Axis channel numbers 0-17
@@ -37,20 +42,23 @@ typedef struct __attribute__((__packed__)) {
     uint8_t ly;
     uint8_t rx;
     uint8_t ry;
-    uint8_t z;
-    uint8_t rz;
+    uint8_t ld;
+    uint8_t rd;
+    uint8_t ls;
+    uint8_t rs;
 
     input_button_mapping_item_t button_map[INPUT_MAX_BUTTONS];
 } input_map_t;
+
 
 void get_input_map(input_map_t *);
 
 bool parse_input_map(uint8_t *data, size_t data_size, input_map_t *newMap);
 
-uint8_t getAxisFromSbus(const sbus_state_t *sbus, int channel);
+int16_t getAxisFromSbus(const sbus_state_t *sbus, int channel);
 bool isPressed(const sbus_state_t *sbus, const input_button_mapping_item_t *map);
 
-void sbus2gamepad_report(const input_map_t *map, const sbus_state_t *sbus, hid_gamepad_report_t *hid);
+void sbus2gamepad_report(const input_map_t *map, const sbus_state_t *sbus, hid_rcgamepad_report_t *hid);
 
 
 #endif

--- a/install-swd.sh
+++ b/install-swd.sh
@@ -7,7 +7,7 @@ PREFIX=$1
 
 set -x
 
-if [ $PREFIX = "" ]
+if [ "$PREFIX" = "" ]
 then
 
   openocd -f $OPENOCD_IFACE -f $OPENOCD_TARGET -c "program pico-sbus.elf verify reset exit"

--- a/sbus-hid.c
+++ b/sbus-hid.c
@@ -58,7 +58,7 @@ void hid_main()
     uint8_t sbusData[SBUS_MESSAGE_MAX_SIZE] = {};
     sbus_state_t sbus = {};
     int clear_counter = 0;
-    const uint32_t interval_ms = 500;
+    const uint32_t interval_ms = 20;
     uint32_t start_ms = board_millis();
 
     while(1)
@@ -169,18 +169,19 @@ static void send_hid_report(uint8_t report_id, const sbus_state_t *sbus)
     {
         case REPORT_ID_GAMEPAD:
         {
-            if(!sbus->framelost)
+            if (!sbus->framelost)
             {
-                hid_gamepad_report_t report =
-                {
-                    .x = getAxisFromSbus(sbus, input_map.lx),
-                    .y = getAxisFromSbus(sbus, input_map.ly),
-                    .z = getAxisFromSbus(sbus, input_map.z),
-                    .rz = getAxisFromSbus(sbus, input_map.rz),
-                    .rx = getAxisFromSbus(sbus, input_map.rx),
-                    .ry = getAxisFromSbus(sbus, input_map.ry),
-                    .hat = 0,
-                    .buttons = 0};
+                hid_rcgamepad_report_t report =
+                    {
+                        .x = getAxisFromSbus(sbus, input_map.lx),
+                        .y = getAxisFromSbus(sbus, input_map.ly),
+                        .rx = getAxisFromSbus(sbus, input_map.rx),
+                        .ry = getAxisFromSbus(sbus, input_map.ry),
+                        .ls = getAxisFromSbus(sbus, input_map.ls),
+                        .rs = getAxisFromSbus(sbus, input_map.rs),
+                        .ld = getAxisFromSbus(sbus, input_map.ld),
+                        .rd = getAxisFromSbus(sbus, input_map.rd),
+                        .buttons = 0};
 
                 for (int i = 0; i < INPUT_MAX_BUTTONS; ++i)
                 {

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -102,7 +102,7 @@
 #define CFG_TUD_VENDOR            0
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
-#define CFG_TUD_HID_EP_BUFSIZE    16
+#define CFG_TUD_HID_EP_BUFSIZE    32
 
 #ifdef __cplusplus
  }

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -130,7 +130,7 @@ char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "Useless Software Inc.",       // 1: Manufacturer
-  "PICO-SBus a",                   // 2: Product
+  "PICO-SBus RC Joystick",       // 2: Product
   "123456",                      // 3: Serials, should use chip ID
 };
 

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -25,6 +25,7 @@
 
 #include "tusb.h"
 #include "usb_descriptors.h"
+#include "custom-device/rc-joy-hid.h"
 
 /* A combination of interfaces must have a unique product id, since PC will save device driver after the first plug.
  * Same VID/PID with different interface e.g MSC (first), then CDC (later) will possibly cause system error on PC.
@@ -76,7 +77,7 @@ uint8_t const desc_hid_report[] =
   //TUD_HID_REPORT_DESC_KEYBOARD( HID_REPORT_ID(REPORT_ID_KEYBOARD         )),
   //TUD_HID_REPORT_DESC_MOUSE   ( HID_REPORT_ID(REPORT_ID_MOUSE            )),
   //TUD_HID_REPORT_DESC_CONSUMER( HID_REPORT_ID(REPORT_ID_CONSUMER_CONTROL )),
-  TUD_HID_REPORT_DESC_GAMEPAD ( HID_REPORT_ID(REPORT_ID_GAMEPAD          ))
+  TUD_HID_REPORT_DESC_RCGAMEPAD ( HID_REPORT_ID(REPORT_ID_GAMEPAD          ))
 };
 
 // Invoked when received GET HID REPORT DESCRIPTOR
@@ -129,7 +130,7 @@ char const* string_desc_arr [] =
 {
   (const char[]) { 0x09, 0x04 }, // 0: is supported language is English (0x0409)
   "Useless Software Inc.",       // 1: Manufacturer
-  "PICO-SBus",                   // 2: Product
+  "PICO-SBus a",                   // 2: Product
   "123456",                      // 3: Serials, should use chip ID
 };
 


### PR DESCRIPTION
Changes device descriptor to allow for all proportional controls to be represented as proportional (8 channels) and the remaining channels are mapped as buttons.
